### PR TITLE
Renamed dispatcherServlet to cxfServlet - fails actuator endpoints

### DIFF
--- a/step1_simple_springboot_app_with_cxf/src/main/java/de/jonashackt/tutorial/SimpleBootCxfApplication.java
+++ b/step1_simple_springboot_app_with_cxf/src/main/java/de/jonashackt/tutorial/SimpleBootCxfApplication.java
@@ -16,7 +16,7 @@ public class SimpleBootCxfApplication {
     }
 
     @Bean
-    public ServletRegistrationBean dispatcherServlet() {
+    public ServletRegistrationBean cxfServlet() {
         return new ServletRegistrationBean(new CXFServlet(), "/soap-api/*");
     }
 

--- a/step2_wsdl_2_java_maven/src/main/java/de/jonashackt/tutorial/SimpleBootCxfApplication.java
+++ b/step2_wsdl_2_java_maven/src/main/java/de/jonashackt/tutorial/SimpleBootCxfApplication.java
@@ -16,7 +16,7 @@ public class SimpleBootCxfApplication {
     }
 
     @Bean
-    public ServletRegistrationBean dispatcherServlet() {
+    public ServletRegistrationBean cxfServlet() {
         return new ServletRegistrationBean(new CXFServlet(), "/soap-api/*");
     }
 

--- a/step3_jaxws-endpoint-cxf-spring-boot-orig-wsdl/src/main/java/de/jonashackt/tutorial/configuration/WebServiceConfiguration.java
+++ b/step3_jaxws-endpoint-cxf-spring-boot-orig-wsdl/src/main/java/de/jonashackt/tutorial/configuration/WebServiceConfiguration.java
@@ -18,7 +18,7 @@ import de.jonashackt.tutorial.endpoint.WeatherServiceEndpoint;
 public class WebServiceConfiguration {
 	
     @Bean
-    public ServletRegistrationBean dispatcherServlet() {
+    public ServletRegistrationBean cxfServlet() {
         return new ServletRegistrationBean(new CXFServlet(), "/soap-api/*");
     }
 

--- a/step3_jaxws-endpoint-cxf-spring-boot/src/main/java/de/jonashackt/tutorial/configuration/WebServiceConfiguration.java
+++ b/step3_jaxws-endpoint-cxf-spring-boot/src/main/java/de/jonashackt/tutorial/configuration/WebServiceConfiguration.java
@@ -17,7 +17,7 @@ import de.jonashackt.tutorial.endpoint.WeatherServiceEndpoint;
 public class WebServiceConfiguration {
 	
     @Bean
-    public ServletRegistrationBean dispatcherServlet() {
+    public ServletRegistrationBean cxfServlet() {
         return new ServletRegistrationBean(new CXFServlet(), "/soap-api/*");
     }
 

--- a/step4_test/src/main/java/de/jonashackt/tutorial/configuration/WebServiceConfiguration.java
+++ b/step4_test/src/main/java/de/jonashackt/tutorial/configuration/WebServiceConfiguration.java
@@ -21,7 +21,7 @@ public class WebServiceConfiguration {
     public static final String SERVICE_URL = "/WeatherSoapService_1.0";
     
     @Bean
-    public ServletRegistrationBean dispatcherServlet() {
+    public ServletRegistrationBean cxfServlet() {
         return new ServletRegistrationBean(new CXFServlet(), BASE_URL + "/*");
     }
 

--- a/step5_custom-soap-fault/src/main/java/de/jonashackt/tutorial/configuration/WebServiceConfiguration.java
+++ b/step5_custom-soap-fault/src/main/java/de/jonashackt/tutorial/configuration/WebServiceConfiguration.java
@@ -23,7 +23,7 @@ public class WebServiceConfiguration {
     public static final String SERVICE_URL = "/WeatherSoapService_1.0";
     
     @Bean
-    public ServletRegistrationBean dispatcherServlet() {
+    public ServletRegistrationBean cxfServlet() {
         return new ServletRegistrationBean(new CXFServlet(), BASE_URL + "/*");
     }
 


### PR DESCRIPTION
Hi @jonashackt, thanks for your CXF with Spring Boot tutorial, it is super helpful. I noticed one small issue - the CXFServlet has been named the "dispatcherServlet" bean in your configuration, this should ideally be something other than dispatcherServlet as then the Spring real Dispatcher Servlet does not get initialized by Spring boot because of name conflict. If there are actuator endpoints like /trace, /beans, /autoconfig those then don't get exposed. If the dispatcherServlet is changed to say cxfServlet then those endpoints also work now.
